### PR TITLE
callisto: init

### DIFF
--- a/callisto/.gitignore
+++ b/callisto/.gitignore
@@ -1,0 +1,6 @@
+PKGBUILD
+*.pkg.tar.*
+pkg/
+src/
+
+callisto-*.tgz

--- a/callisto/Makefile
+++ b/callisto/Makefile
@@ -1,0 +1,11 @@
+PKG = callisto
+
+PKGBUILD:
+	git clone --depth=1 https://aur.archlinux.org/${PKG}.git
+	cp -f ${PKG}/PKGBUILD .
+	rm -rf ${PKG}
+
+clean:
+	rm -rf PKGBUILD src pkg *.pkg.tar.* callisto-*.tgz
+
+.PHONY: clean

--- a/pkgs/Makefile
+++ b/pkgs/Makefile
@@ -2,6 +2,7 @@ MAKEPKG = makepkg -cs --noconfirm --nosign
 REPOADD = repo-add
 
 PKGS   = alacritty-sixel      \
+         callisto             \
          ktechlab             \
          lite-xl              \
          ly                   \


### PR DESCRIPTION
Adds a package for [callisto](https://github.com/jtbx/callisto), a standalone scripting platform for Lua 5.4 designed for ease of use with POSIX APIs.